### PR TITLE
Fix issue with smtp_send_mail_with_template method

### DIFF
--- a/pysendpulse/pysendpulse.py
+++ b/pysendpulse/pysendpulse.py
@@ -677,7 +677,7 @@ class PySendPulse:
             return self.__handle_error('Seems we have empty subject')
         elif not email.get('from') or not email.get('to'):
             return self.__handle_error("Seems we have empty some credentials 'from': '{}' or 'to': '{}' fields".format(email.get('from'), email.get('to')))
-        email['html'] = base64.b64encode(email.get('html').encode('utf-8')).decode('utf-8')
+        email['html'] = base64.b64encode(email.get('html').encode('utf-8')).decode('utf-8') if email['html'] else None
         return self.__handle_result(self.__send_request('smtp/emails', 'POST', {'email': json.dumps(email)}))
 
     def smtp_send_mail_with_template(self, email):


### PR DESCRIPTION
There is error when using `smtp_send_mail_with_template` method
```
  File "........./pysendpulse/pysendpulse.py", line 680, in smtp_send_mail
    email['html'] = base64.b64encode(email.get('html').encode('utf-8')).decode('utf-8')
AttributeError: 'NoneType' object has no attribute 'encode'
```
This error caused by `email['html'] = email['text'] = None` on line 694
https://github.com/sendpulse/sendpulse-rest-api-python/blob/master/pysendpulse/pysendpulse.py#L694
After passing this `None` value to the `smtp_send_mail` we will get error because `smtp_send_mail` trying to encode html attribute.
That why we need to add a condition to check if there any value in the `email['html']` at all.