### PR TITLE
Pass object not string to send_request

### DIFF
--- a/pysendpulse/pysendpulse.py
+++ b/pysendpulse/pysendpulse.py
@@ -688,7 +688,7 @@ class PySendPulse:
         elif not email.get('from') or not email.get('to'):
             return self.__handle_error("Seems we have empty some credentials 'from': '{}' or 'to': '{}' fields".format(email.get('from'), email.get('to')))
         email['html'] = base64.b64encode(email.get('html').encode('utf-8')).decode('utf-8') if email['html'] else None
-        return self.__handle_result(self.__send_request('smtp/emails', 'POST', {'email': json.dumps(email)}))
+        return self.__handle_result(self.__send_request('smtp/emails', 'POST', {'email': email}))
 
     def smtp_send_mail_with_template(self, email):
         """ SMTP: send email with custom template


### PR DESCRIPTION
send_request stringifies the entire body so smtp_send_email should pass object not already-stringified content